### PR TITLE
feat: Interrogate all AWS accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -256,6 +256,55 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-organizations": {
+      "version": "3.477.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-organizations/-/client-organizations-3.477.0.tgz",
+      "integrity": "sha512-hjNNPdCETAVDJxejIvIwySFcfSKvpeNNFeFs1hTMMLpbpOYlYlIGXKNL7ib+mh+345GWYPax5tOZTp+M2C83nw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.477.0",
+        "@aws-sdk/core": "3.477.0",
+        "@aws-sdk/credential-provider-node": "3.477.0",
+        "@aws-sdk/middleware-host-header": "3.468.0",
+        "@aws-sdk/middleware-logger": "3.468.0",
+        "@aws-sdk/middleware-recursion-detection": "3.468.0",
+        "@aws-sdk/middleware-signing": "3.468.0",
+        "@aws-sdk/middleware-user-agent": "3.470.0",
+        "@aws-sdk/region-config-resolver": "3.470.0",
+        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/util-endpoints": "3.470.0",
+        "@aws-sdk/util-user-agent-browser": "3.468.0",
+        "@aws-sdk/util-user-agent-node": "3.470.0",
+        "@smithy/config-resolver": "^2.0.21",
+        "@smithy/fetch-http-handler": "^2.3.1",
+        "@smithy/hash-node": "^2.0.17",
+        "@smithy/invalid-dependency": "^2.0.15",
+        "@smithy/middleware-content-length": "^2.0.17",
+        "@smithy/middleware-endpoint": "^2.2.3",
+        "@smithy/middleware-retry": "^2.0.24",
+        "@smithy/middleware-serde": "^2.0.15",
+        "@smithy/middleware-stack": "^2.0.9",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/node-http-handler": "^2.2.1",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.22",
+        "@smithy/util-defaults-mode-node": "^2.0.29",
+        "@smithy/util-endpoints": "^1.0.7",
+        "@smithy/util-retry": "^2.0.8",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.477.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.477.0.tgz",
@@ -11442,7 +11491,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@aws-sdk/client-auto-scaling": "^3.477.0",
-        "@aws-sdk/credential-providers": "^3.477.0"
+        "@aws-sdk/client-organizations": "^3.477.0",
+        "@aws-sdk/credential-providers": "^3.477.0",
+        "@smithy/util-retry": "^2.0.8"
       },
       "devDependencies": {
         "@smithy/types": "^2.7.0",

--- a/packages/cdk/lib/__snapshots__/aws-asg-monitor.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/aws-asg-monitor.test.ts.snap
@@ -37,7 +37,7 @@ exports[`The AwsAsgMonitor stack matches the snapshot 1`] = `
           },
         },
         "Handler": "index.main",
-        "MemorySize": 512,
+        "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [
             "AwsAsgMonitorServiceRole5F798240",
@@ -67,7 +67,7 @@ exports[`The AwsAsgMonitor stack matches the snapshot 1`] = `
             "Value": "INFRA",
           },
         ],
-        "Timeout": 30,
+        "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -98,7 +98,6 @@ exports[`The AwsAsgMonitor stack matches the snapshot 1`] = `
               ],
             ],
           },
-          "arn:aws:iam::aws:policy/AutoScalingReadOnlyAccess",
         ],
         "Tags": [
           {
@@ -204,6 +203,16 @@ exports[`The AwsAsgMonitor stack matches the snapshot 1`] = `
                   ],
                 ],
               },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::*:role/cloudquery-access",
+            },
+            {
+              "Action": "organizations:List*",
+              "Effect": "Allow",
+              "Resource": "*",
             },
           ],
           "Version": "2012-10-17",

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-auto-scaling": "^3.477.0",
-    "@aws-sdk/credential-providers": "^3.477.0"
+    "@aws-sdk/client-organizations": "^3.477.0",
+    "@aws-sdk/credential-providers": "^3.477.0",
+    "@smithy/util-retry": "^2.0.8"
   }
 }

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -1,28 +1,55 @@
 import type { Activity } from '@aws-sdk/client-auto-scaling';
 import { AutoScalingClient } from '@aws-sdk/client-auto-scaling';
-import { awsClientConfig, getActivities, listAutoScalingGroups } from './asg';
+import {
+	awsClientConfig,
+	getActivities,
+	getAwsAccounts,
+	listAutoScalingGroups,
+} from './aws';
 import { getConfig } from './config';
 
 export async function main() {
 	const { stage } = getConfig();
 
-	const client = new AutoScalingClient(awsClientConfig(stage));
-
-	const autoScalingGroups = await listAutoScalingGroups(client);
-	console.log(`Total ASGs ${autoScalingGroups.length}`);
+	const accounts = await getAwsAccounts(stage);
+	console.log(`Total accounts ${accounts.length}`);
 
 	await Promise.all(
-		autoScalingGroups.map(async (asg) => {
-			const asgName = asg.AutoScalingGroupName;
+		accounts.map(async (account) => {
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- AWS's types are wrong!
+			const accountId = account.Id!;
 
-			if (!asgName) {
-				throw new Error('ASG name is undefined');
-			}
+			/*
+			A bit of a hack... this role is used by Service Catalogue,
+			and has read access to all our accounts.
 
-			const activities = await getActivities(client, asgName);
-			console.log(`Total activities for ${asgName}: ${activities.length}`);
+			Yes, we are not following the principle of least privilege,
+			but this repository isn't meant to be running for very long...
 
-			activities.forEach(logActivity);
+			See https://github.com/guardian/aws-account-setup/blob/main/packages/cdk/lib/constructs/cloudquery-role.ts.
+
+			TODO provision a dedicated role for this service.
+			 */
+			const roleArn = `arn:aws:iam::${accountId}:role/cloudquery-access`;
+
+			const client = new AutoScalingClient(awsClientConfig(stage, roleArn));
+			const autoScalingGroups = await listAutoScalingGroups(client);
+			console.log(`Total ASGs ${autoScalingGroups.length}`);
+
+			await Promise.all(
+				autoScalingGroups.map(async (asg) => {
+					const asgName = asg.AutoScalingGroupName;
+
+					if (!asgName) {
+						throw new Error('ASG name is undefined');
+					}
+
+					const activities = await getActivities(client, asgName);
+					console.log(`Total activities for ${asgName}: ${activities.length}`);
+
+					activities.forEach(logActivity);
+				}),
+			);
 		}),
 	);
 }


### PR DESCRIPTION
Update the lambda to read ASG activity in all accounts.

We're cheating a ~little~ lot by using the role provisioned for https://github.com/guardian/service-catalogue 😬.