### PR TITLE
feat: Run the lambda on a schedule

### DIFF
--- a/packages/cdk/lib/__snapshots__/aws-asg-monitor.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/aws-asg-monitor.test.ts.snap
@@ -5,7 +5,7 @@ exports[`The AwsAsgMonitor stack matches the snapshot 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuDistributionBucketParameter",
-      "GuLambdaFunction",
+      "GuScheduledLambda",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -70,6 +70,43 @@ exports[`The AwsAsgMonitor stack matches the snapshot 1`] = `
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "AwsAsgMonitorAwsAsgMonitorrate1day08837BDC4": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 day)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "AwsAsgMonitor8BB96673",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "AwsAsgMonitorAwsAsgMonitorrate1day0AllowEventRuleAwsAsgMonitor7137BFF3DF561CF7": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "AwsAsgMonitor8BB96673",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "AwsAsgMonitorAwsAsgMonitorrate1day08837BDC4",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "AwsAsgMonitorServiceRole5F798240": {
       "Properties": {

--- a/packages/cdk/lib/aws-asg-monitor.ts
+++ b/packages/cdk/lib/aws-asg-monitor.ts
@@ -1,8 +1,9 @@
+import { GuScheduledLambda } from '@guardian/cdk';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
-import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
+import { Schedule } from 'aws-cdk-lib/aws-events';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
@@ -17,7 +18,17 @@ export class AwsAsgMonitor extends GuStack {
 		 *
 		 * @see The `__snapshots__` directory for more.
 		 */
-		const lambda = new GuLambdaFunction(this, 'AwsAsgMonitor', {
+		const lambda = new GuScheduledLambda(this, 'AwsAsgMonitor', {
+			// TODO add monitoring if this service is going to exist long-term.
+			monitoringConfiguration: { noMonitoring: true },
+
+			// Run once a day.
+			rules: [
+				{
+					schedule: Schedule.rate(Duration.days(1)),
+				},
+			],
+
 			/**
 			 * This becomes the value of the APP tag on provisioned resources.
 			 */


### PR DESCRIPTION
As the lambda is collecting all available activity on each invocation, running it more than once a day might get confusing?